### PR TITLE
Send Ping event before endpoint event.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ app.post('/messages', async (c) => {
     return c.text('No transport found for sessionId', 400);
   }
 
-  return transport.handlePostMessage(c);
+  return await transport.handlePostMessage(c);
 });
 
 serve(

--- a/src/sse.ts
+++ b/src/sse.ts
@@ -43,7 +43,10 @@ export class SSETransport implements Transport {
     if (this.stream.closed) {
       throw new Error('SSE transport already closed!');
     }
-
+    await this.stream.writeSSE({
+      event: 'ping',
+      data: '',
+    });
     await this.stream.writeSSE({
       event: 'endpoint',
       data: `${this.messageUrl}?sessionId=${this.sessionId}`,


### PR DESCRIPTION
The endpoint event was not sent and hung up during initialization, so we sent a random ping event to force it to be sent.